### PR TITLE
Add in-app theme toggle

### DIFF
--- a/TodoApp/Application/TodoAppApp.swift
+++ b/TodoApp/Application/TodoAppApp.swift
@@ -11,16 +11,18 @@ import SwiftUI
 struct TodoAppApp: App {
 
     @State private var firsTimeLogin: Bool = UserDefaults.standard.bool(forKey: "firstTimeLogin")
+    @StateObject private var themeManager = ThemeManager()
 
     var body: some Scene {
         WindowGroup {
-
             if self.firsTimeLogin {
                 MainView()
-            }
-            else {
+                    .environmentObject(themeManager)
+                    .preferredColorScheme(themeManager.selectedTheme.colorScheme)
+            } else {
                 AnyView(OnboardingView(getStartedTapped: $firsTimeLogin))
-
+                    .environmentObject(themeManager)
+                    .preferredColorScheme(themeManager.selectedTheme.colorScheme)
             }
         }
     }

--- a/TodoApp/Core/Managers/ThemeManager.swift
+++ b/TodoApp/Core/Managers/ThemeManager.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+final class ThemeManager: ObservableObject {
+    enum Theme: String {
+        case light
+        case dark
+
+        var colorScheme: ColorScheme {
+            switch self {
+            case .light: return .light
+            case .dark: return .dark
+            }
+        }
+    }
+
+    @Published var selectedTheme: Theme {
+        didSet { UserDefaults.standard.set(selectedTheme.rawValue, forKey: "selectedTheme") }
+    }
+
+    init() {
+        let value = UserDefaults.standard.string(forKey: "selectedTheme") ?? Theme.dark.rawValue
+        selectedTheme = Theme(rawValue: value) ?? .dark
+    }
+
+    func toggle() {
+        selectedTheme = selectedTheme == .light ? .dark : .light
+    }
+}

--- a/TodoApp/Views/Main/HeaderView/MainHeaderView.swift
+++ b/TodoApp/Views/Main/HeaderView/MainHeaderView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainHeaderView: View {
 
     @ObservedObject var viewModel: MainHeaderViewModel
+    @EnvironmentObject var themeManager: ThemeManager
 
     var body: some View {
         ZStack {
@@ -31,6 +32,13 @@ struct MainHeaderView: View {
                     .padding(.leading)
 
                     Spacer()
+
+                    Button(action: { themeManager.toggle() }) {
+                        Image(systemName: themeManager.selectedTheme == .dark ? "sun.max.fill" : "moon.fill")
+                            .imageScale(.large)
+                            .foregroundColor(.white)
+                    }
+                    .padding(.trailing, 8)
 
                     Image("photo")
                         .frame(width: 40, height: 40)
@@ -82,5 +90,6 @@ struct MainHeaderView: View {
 struct MainHeaderView_Previews: PreviewProvider {
     static var previews: some View {
         MainHeaderView(viewModel: MainHeaderViewModel(dataManager: MockDataManager.shared))
+            .environmentObject(ThemeManager())
     }
 }

--- a/TodoApp/Views/Main/MainView.swift
+++ b/TodoApp/Views/Main/MainView.swift
@@ -46,6 +46,7 @@ struct MainView: View {
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {
         MainView()
+            .environmentObject(ThemeManager())
             .preferredColorScheme(.dark)
     }
 }


### PR DESCRIPTION
## Summary
- create `ThemeManager` to hold selected theme and handle toggling
- provide theme manager in `TodoAppApp` and apply preferred color scheme
- add light/dark toggle button in `MainHeaderView`
- update previews

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6845b1c7406c8332b2e8620513696784