### PR TITLE
Fix time formatter to display minutes

### DIFF
--- a/TodoApp/Core/Extensions/Date+Extension.swift
+++ b/TodoApp/Core/Extensions/Date+Extension.swift
@@ -73,5 +73,5 @@ enum DateFormatterPool {
     }
 
     static let dayMonthYearFormatter = DateFormatterPool.get(format: "dd MMM, yyyy")
-    static let timeFormatter = DateFormatterPool.get(format: "hh:ss a")
+    static let timeFormatter = DateFormatterPool.get(format: "hh:mm a")
 }


### PR DESCRIPTION
## Summary
- update Date extension formatter string to use `hh:mm a`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68499d82839883329a2acbec87096eeb